### PR TITLE
use Type list

### DIFF
--- a/src/Data/Tuple/Ops/Internal.hs
+++ b/src/Data/Tuple/Ops/Internal.hs
@@ -15,33 +15,60 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE PolyKinds #-}
 module Data.Tuple.Ops.Internal where
 
 import qualified GHC.Generics as G
 import GHC.Generics (Generic(..), (:*:)(..), (:+:)(..), Rec0, C1, D1, S1, M1(..), U1, K1(..))
 import Data.Proxy
+import Data.Type.Combinator
 import Data.Type.Product
 import Type.Family.List
+import Type.Class.Witness
 import qualified Type.Family.Nat as Nat
 import qualified Prelude as P 
-import Prelude (Maybe(..), Int, Word, Char, Float, Double, Bool(..), ($))
+import Prelude (Maybe(..), Int, Word, Char, Float, Double, Bool(..), ($), (.))
+
+newtype TupleR (f :: [* -> *]) x = TupleR { unTupleR :: Tuple (f <&> x)}
+
+-- class X' (t :: * -> *) where
+--     type X t :: [* -> *]
+--     foo :: t x -> TupleR (X t) x
+  
+-- instance X' v => X' (u :*: v) where
+--     type X (u :*: v) = u : X v
+--     foo (a :*: b) = TupleR $ I a :< (unTupleR $ foo b)
+
+aaa :: Wit (((a :< b) ++ c) ~ (a :< (b ++ c)))
+aaa = Wit
+bbb :: Wit (((a :< b) <&> x) ~ ((a x) :< (b <&> x)))
+bbb = Wit
+class MyWit (a :: [* -> *]) where
+    ccc :: Wit (((a ++ b) <&> x) ~ ((a <&> x) ++ (b <&> x)))
+instance MyWit '[] where
+    ccc = Wit
+instance MyWit (a :< as) where
+    ccc = Wit
 
 -- | Representation of tuple are shaped in a balanced tree. 
 -- 'L' transforms the tree into a list, for further manipulation.
 class Linearize (t :: * -> *) where
   type L t :: [* -> *]
-  linearize :: t x -> Tuple (L t <&> x)
+  linearize :: t x -> TupleR (L t) x
 
 -- | base case. sinleton
 instance Linearize (S1 MetaS (Rec0 t)) where
-    type L (S1 MetaS (Rec0 t)) = [S1 MetaS (Rec0 t)]
-    linearize = only
+    type L (S1 MetaS (Rec0 t)) = '[S1 MetaS (Rec0 t)]
+    linearize = TupleR . only . I
 
 -- | inductive case. preppend a product with what ever
 instance (Linearize v, Linearize u) => Linearize (u :*: v) where
     type L (u :*: v) = L u ++ L v
-    linearize (a :*: b) = append' (linearize a) (linearize b)
+    linearize (a :*: b) = TupleR $ append' (unTupleR $ linearize a) (unTupleR $ linearize b)
+
+length' :: TupleR a x -> Proxy (Nat.Len a)
+length' _ = Proxy
 
 -- | calculate the half
 type family Half (a :: Nat.N) :: Nat.N where
@@ -55,7 +82,7 @@ half _ = Proxy
 -- | take the first n elements from a product
 class Take (n :: Nat.N) (a :: [* -> *]) where
     type T n a :: [* -> *]
-    take :: Proxy n -> Tuple (a <&> x) -> Tuple (T n a <&> x)
+    take :: Proxy n -> TupleR a x -> TupleR (T n a) x
 
 -- | base case. take one out of singleton
 instance Take Nat.Z xs where
@@ -65,12 +92,12 @@ instance Take Nat.Z xs where
 -- | inductive case. take (n+1) elements
 instance Take n xs => Take (Nat.S n) (x : xs) where
     type T (Nat.S n) (x : xs) = x : T n xs
-    take (_ :: Proxy (Nat.S n)) (a : as) = a : take (Proxy :: Proxy n) b
+    take (_ :: Proxy (Nat.S n)) (TupleR (a :< as)) = TupleR (a :< unTupleR (take (Proxy :: Proxy n) (TupleR as)))
 
 -- | drop the first n elements from a product
 class Drop (n :: Nat.N) (a :: [* -> *]) where
     type D n a :: [* -> *]
-    drop :: Proxy n -> Tuple (a <&> x) -> Tuple (D n a <&> x)
+    drop :: Proxy n -> TupleR a x -> TupleR (D n a) x
 
 -- | base case. drop one from product
 instance Drop Nat.Z as where
@@ -78,29 +105,29 @@ instance Drop Nat.Z as where
     drop _ a = a
 
 -- | inductive case. drop (n+1) elements
-instance Drop n b => Drop (Nat.S n) (a : as) where
+instance Drop n as => Drop (Nat.S n) (a : as) where
     type D (Nat.S n) (a : as) = D n as
-    drop (_ :: Proxy (Nat.S n)) (a : as) = drop (Proxy :: Proxy n) as
+    drop (_ :: Proxy (Nat.S n)) (TupleR (a :< as)) = drop (Proxy :: Proxy n) (TupleR as)
 
 -- | 'Normalize' converts a linear product back into a balanced tree.
 class Normalize (a :: [* -> *]) where
     type N a :: * -> *
-    normalize :: Tuple [a <&> x] -> N a x
+    normalize :: TupleR a x -> N a x
 
 -- | base case. singleton
-instance Normalize [S1 MetaS (Rec0 t)] where
-    type N [S1 MetaS (Rec0 t)] = S1 MetaS (Rec0 t)
-    normalize a = head' a
+instance Normalize '[S1 MetaS (Rec0 t)] where
+    type N '[S1 MetaS (Rec0 t)] = S1 MetaS (Rec0 t)
+    normalize a = getI $ head' $ unTupleR a
 
 -- | inductive case. product
-instance (Take (Half (Nat.N1 Nat.+ Nat.Len b)) (a :< b),
-          Drop (Half (Nat.N1 Nat.+ Nat.Len b)) (a :< b),
-          Normalize (T (Half (Nat.N1 Nat.+ Nat.Len b)) (a :< b)), 
-          Normalize (D (Half (Nat.N1 Nat.+ Nat.Len b)) (a :< b))) 
-    => Normalize (a :< b) where
-    type N (a :< b) = N (T (Half (Nat.N1 Nat.+ Nat.Len b)) (a :< b)) :*: 
-                      N (D (Half (Nat.N1 Nat.+ Nat.Len b)) (a :< b))
-    normalize v = let n = half (length v :: Proxy (Nat.N1 Nat.+ Nat.Len b))
+instance (Take (Half (Nat.N2 Nat.+ Nat.Len c)) (a :< b :< c),
+          Drop (Half (Nat.N2 Nat.+ Nat.Len c)) (a :< b :< c),
+          Normalize (T (Half (Nat.N2 Nat.+ Nat.Len c)) (a :< b :< c)), 
+          Normalize (D (Half (Nat.N2 Nat.+ Nat.Len c)) (a :< b :< c))) 
+    => Normalize (a :< b :< c) where
+    type N (a :< b :< c) = N (T (Half (Nat.N2 Nat.+ Nat.Len c)) (a :< b :< c)) :*: 
+                           N (D (Half (Nat.N2 Nat.+ Nat.Len c)) (a :< b :< c))
+    normalize v = let n = half (length' v)
                   in normalize (take n v) :*: normalize (drop n v)
 
 type MetaS = 'G.MetaSel 'Nothing 'G.NoSourceUnpackedness 'G.NoSourceStrictness 'G.DecidedLazy

--- a/src/Data/Tuple/Ops/Internal.hs
+++ b/src/Data/Tuple/Ops/Internal.hs
@@ -67,9 +67,9 @@ length' _ = Proxy
 
 -- | calculate the half
 type family Half (a :: Nat.N) :: Nat.N where
-    Half (Nat.S Nat.Z) = Nat.Z
-    Half (Nat.S (Nat.S Nat.Z)) = Nat.S Nat.Z
-    Half (Nat.S (Nat.S n)) = Nat.S (Half n)
+    Half ('Nat.S 'Nat.Z) = 'Nat.Z
+    Half ('Nat.S ('Nat.S 'Nat.Z)) = 'Nat.S 'Nat.Z
+    Half ('Nat.S ('Nat.S n)) = 'Nat.S (Half n)
 -- | calculate the half
 half :: Proxy n -> Proxy (Half n)
 half _ = Proxy

--- a/src/Data/Tuple/Ops/Internal.hs
+++ b/src/Data/Tuple/Ops/Internal.hs
@@ -14,6 +14,9 @@
 ------------------------------------------------------------
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Data.Tuple.Ops.Internal where
 
 import GHC.Generics ((:*:)(..), Rec0, D1, S1, Meta(..), SourceUnpackedness(..), SourceStrictness(..), DecidedStrictness(..))
@@ -138,3 +141,6 @@ type family UnS1 t where
 -- | utility type function to trim the D1
 type family UnD1 t where
     UnD1 (D1 _ t) = t
+-- | utility type function to extract the meta information
+type family MetaOfD1 t where
+    MetaOfD1 (D1 m _) = m

--- a/src/Data/Tuple/Ops/Uncons.hs
+++ b/src/Data/Tuple/Ops/Uncons.hs
@@ -24,6 +24,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Data.Tuple.Ops.Uncons (uncons, Uncons, Unconsable) where
 
@@ -131,9 +132,9 @@ type family Uncons a where
 -- | A constraint on any 'uncons'able data type, where
 -- @a@ is the input type, and @(b,c)@ is the output type
 type Unconsable a b c = (Generic a, Generic b, Generic c, Uncons a ~ (b, c),
-                         Rep a ~ D1 MetaS (UnD1 (Rep a)), 
-                         Rep b ~ D1 MetaS (UnD1 (Rep b)), 
-                         Rep c ~ D1 MetaS (UnD1 (Rep c)),
+                         Rep a ~ D1 (MetaOfD1 (Rep a)) (UnD1 (Rep a)), 
+                         Rep b ~ D1 (MetaOfD1 (Rep b)) (UnD1 (Rep b)), 
+                         Rep c ~ D1 (MetaOfD1 (Rep c)) (UnD1 (Rep c)),
                          UnconsR (UnD1 (Rep a)), 
                          HeadR (UnD1 (Rep a)) ~ (UnD1 (Rep b)), 
                          TailR (UnD1 (Rep a)) ~ (UnD1 (Rep c)))

--- a/src/Data/Tuple/Ops/Uncons.hs
+++ b/src/Data/Tuple/Ops/Uncons.hs
@@ -22,31 +22,34 @@
 --
 ------------------------------------------------------------
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Data.Tuple.Ops.Uncons (uncons, Uncons) where
 
-import qualified GHC.Generics as G
-import GHC.Generics (Generic(..), (:*:)(..), (:+:)(..), Rec0, C1, D1, S1, M1(..), U1, K1(..))
-import GHC.TypeLits
+import GHC.Generics (Generic(..), (:*:)(..), (:+:)(..), URec, Rec0, C1, D1, S1, M1(..), U1, K1(..), Meta(..), FixityI(..))
+import GHC.TypeLits (Symbol)
+import Data.Proxy
+import Type.Family.Nat (N1)
 import Data.Tuple.Ops.Internal
 
 -- | representation of a pair
-type RepOfPair t1 t2 = C1 ('G.MetaCons "(,)" 'G.PrefixI 'False) (S1 MetaS (Rec0 t1) :*: S1 MetaS (Rec0 t2))
+type RepOfPair t1 t2 = C1 ('MetaCons "(,)" 'PrefixI 'False) (S1 MetaS (Rec0 t1) :*: S1 MetaS (Rec0 t2))
 -- | representation of a tuple of arity > 2, in which @/u/@ is of the form @_ :*: _@
-type RepOfTuple c u = C1 ('G.MetaCons c 'G.PrefixI 'False) u 
+type RepOfTuple c u = C1 ('MetaCons c 'PrefixI 'False) u 
 
 -- | 'HeadR' is a type function that takes the first element of a tuple
 type family HeadR (f :: * -> *) :: * -> * where
-    HeadR (C1 mc (S1 ms (G.URec a))) = C1 mc (S1 ms (G.URec a))
+    HeadR (C1 mc (S1 ms (URec a))) = C1 mc (S1 ms (URec a))
     HeadR (a :+: b) = a :+: b
     HeadR (RepOfPair t1 t2) = UnD1 (Rep t1)
-    HeadR (RepOfTuple tcon (a :*: b :*: c)) = UnD1 (Rep (UnRec0 (UnS1 (T One (L (a :*: b :*: c) End)))))
+    HeadR (RepOfTuple tcon (a :*: b :*: c)) = UnD1 (Rep (UnRec0 (UnS1 (N (T N1 (L (a :*: b :*: c)))))))
 -- | 'TailR' is a type function that drops the first element of a tuple
 type family TailR (f :: * -> *) :: * -> * where
-    TailR (C1 mc (S1 ms (G.URec a))) = C1 ('G.MetaCons "()" 'G.PrefixI 'False) U1
-    TailR (a :+: b) = C1 ('G.MetaCons "()" 'G.PrefixI 'False) U1
+    TailR (C1 mc (S1 ms (URec a))) = C1 ('MetaCons "()" 'PrefixI 'False) U1
+    TailR (a :+: b) = C1 ('MetaCons "()" 'PrefixI 'False) U1
     TailR (RepOfPair t1 t2) = UnD1 (Rep t2)
-    TailR (RepOfTuple tcon (a :*: b :*: c)) = RepOfTuple (TupleConPred tcon) (N (D One (L (a :*: b :*: c) End)))
+    TailR (RepOfTuple tcon (a :*: b :*: c)) = RepOfTuple (TupleConPred tcon) (N (D N1 (L (a :*: b :*: c))))
 
 -- | Abstract type class for generic representation of a /uncons/able datatype
 class UnconsR f where
@@ -55,7 +58,7 @@ class UnconsR f where
 -- | primitive datatype
 -- 'HeadR' is the datatype itself
 -- 'TailR' is ()
-instance UnconsR (C1 mc (S1 ms (G.URec a))) where
+instance UnconsR (C1 mc (S1 ms (URec a))) where
     unconsR a = (a, unM1 (from ()))
 
 -- | sum datatype
@@ -75,12 +78,17 @@ instance (Generic t1, Rep t1 ~ D1 mt1 ct1,
 -- | tuple of arity > 2
 -- 'HeadR' is the first element
 -- 'TailR' is the rest all elements
-instance (Linearize c End, Linearize b (L c End), Linearize a (L b (L c End)),
-          L a (L b (L c End)) ~ (S1 MetaS (Rec0 t) :*: w), 
+instance (Linearize (a :*: b :*: c), L (a :*: b :*: c) ~ (S1 MetaS (Rec0 t) : w), 
           Generic t, Rep t ~ D1 hm hc, Normalize w) 
     => UnconsR (RepOfTuple tcon (a :*: b :*: c)) where
-    unconsR a = case linearize (unM1 a) End of
-                  u :*: v -> (unM1 $ from $ unK1 $ unM1 u, M1 $ normalize v)
+    unconsR a = let tup = linearize (unM1 a)
+                    one = Proxy :: Proxy N1
+                    h = unM1 $ from $ unK1 $ unM1 $ normalize $ take' one tup
+                    t = M1 $ normalize $ drop' one tup
+                in (h, t)
+    -- unconsR a = case linearize (unM1 a) of
+    --               (TupleR (u :< v) :: TupleR (S1 MetaS (Rec0 t) : w) x) -> 
+    --                 (unM1 $ from $ (unK1 (unM1 (getI u)) :: t), M1 $ normalize $ (TupleR v :: TupleR w x))
 
 -- | calculate the tuple constructor of the size 1 smaller
 -- upto the tupel of arity of 16

--- a/tuple-ops.cabal
+++ b/tuple-ops.cabal
@@ -1,5 +1,5 @@
 name:                       tuple-ops
-version:                    0.0.0.0
+version:                    0.0.0.1
 category:                   Data
 author:                     Jiasen Wu
 maintainer:                 Jiasen Wu <jiasenwu@hotmail.com>
@@ -21,7 +21,6 @@ Library
                           , TypeOperators
                           , KindSignatures
                           , TypeFamilies
-                          , UndecidableInstances
                           , FlexibleInstances
     build-depends:          base >= 4.7 && < 5.0
                           , type-combinators == 0.2.4.3

--- a/tuple-ops.cabal
+++ b/tuple-ops.cabal
@@ -24,3 +24,4 @@ Library
                           , UndecidableInstances
                           , FlexibleInstances
     build-depends:          base >= 4.7 && < 5.0
+                          , type-combinators == 0.2.4.3


### PR DESCRIPTION
*type-combinators* provides a type list and generic operations on it. converting the representation to type list could benefit the implementation of other operators.